### PR TITLE
Fix Scraper.create args

### DIFF
--- a/loaders.js
+++ b/loaders.js
@@ -93,7 +93,7 @@ const findOrCreateAsset = async (ctx, id, url) => {
   if (!asset.scraped) {
 
     // Create the Scraper job.
-    await Scraper.create(asset);
+    await Scraper.create(ctx, id);
   }
 
   return asset;


### PR DESCRIPTION
# What does this PR do?

This PR updates arguments for `Scraper.create` based on changes introduced in `coralproject/talk` `4.3.0` -

https://github.com/coralproject/talk/commit/435067f6193fe5e082bcd6828b52903079f7ca94#diff-3729c71313566fd6ca2150242c2504f2

# How do I test this PR?

- Install the plugin
- Visit a page whose asset ID does not exist in Talk
- Confirm the page is scraped successfully